### PR TITLE
Fix track-matte source layer index direction

### DIFF
--- a/fxplayer/src/main/java/com/lottie4j/fxplayer/LottiePlayer.java
+++ b/fxplayer/src/main/java/com/lottie4j/fxplayer/LottiePlayer.java
@@ -730,9 +730,12 @@ public class LottiePlayer extends Canvas {
             if (isLayerActiveAtFrame(layer, frame)) {
                 // Check if this layer uses a track matte (has tt set)
                 if (layer.matteMode() != null) {
-                    // This layer uses a matte - the next layer (i+1) should be the matte source
-                    if (i + 1 < animation.layers().size()) {
-                        Layer matteSource = animation.layers().get(i + 1);
+                    // This layer uses a matte. Per the Lottie/AE convention, the matte source is the
+                    // layer immediately ABOVE the consumer in the After Effects layer panel, which
+                    // corresponds to the IMMEDIATELY PRECEDING layer in the JSON layers array
+                    // (lower index, since index 0 is the top of the rendering stack).
+                    if (i - 1 >= 0) {
+                        Layer matteSource = animation.layers().get(i - 1);
                         if (matteSource.matteTarget() != null && matteSource.matteTarget() == 1
                                 && isLayerActiveAtFrame(matteSource, frame)) {
                             logger.debug("Rendering matted layer {}: {} with matte from {}", i, layer.name(), matteSource.name());


### PR DESCRIPTION
# PR 1 — Fix track-matte source layer index direction

**Branch**: `pr/fix-track-matte-source-direction` (1 commit, 1 file, +6 / -3)

**File**: `fxplayer/src/main/java/com/lottie4j/fxplayer/LottiePlayer.java`

## Title
Fix track-matte source layer index direction

## Description

Per the Lottie spec and After Effects convention, the matte SOURCE layer (`td: 1`) is the one immediately ABOVE the matte consumer (`tt` set) in the AE layer panel. In the Lottie JSON `layers` array — where index 0 is the top of the rendering stack — that means the matte source has the **lower** index (`i - 1`), not the higher one.

The previous implementation looked at `animation.layers().get(i + 1)`, which is the layer one slot below the consumer. With that direction, no track matte ever resolved on real assets and the would-be-masked layer was rendered unclipped, painting over content beneath it.

This matches:
- The project's own `core/src/test/resources/dot/demo-3-animation.json` test fixture, where the `MATTE 2` source at index 1 is consumed by `BTM EYELID` at index 2 (source = consumer − 1).
- airbnb's `lottie-android` and `lottie-web` reference implementations.

### Reproduction

Open the attached `face-exhaling-1f62e_200d_1f4a8.zip` (the 😮‍💨 emoji animation; available at https://googlefonts.github.io/noto-emoji-animation/ or in any noto-emoji-animation distribution).

Layer layout (relevant subset, JSON `layers` array indices):

| index | name          | `td` | `tt` |
|-------|---------------|------|------|
| 15    | base matte    | 1    | —    |
| 16    | base shadow   | —    | 2    |
| 17    | base normal   | —    | —    |

Layer 16 (`base shadow`, an orange filled face shape) declares an alpha-inverted matte (`tt: 2`) sourced from `base matte` (the layer immediately above it in the AE panel = index 15 in the JSON).

**Before the fix**: lottie4j looked at `i + 1 = 17` (`base normal`, which has `td: null`), the matte resolution failed, and `base shadow` rendered without its inverted-alpha clip — its orange fill covered the entire face area, hiding the yellow gradient on `base normal`.

**After the fix**: matte resolution succeeds, `base shadow` is properly clipped to the inverted alpha of `base matte`, and the yellow gradient face renders correctly with the orange shadow only where the matte allows.

## How to test

```bash
mvn -DskipTests install
# then in the fxfileviewer module, open the attached zip's JSON
mvn -pl fxfileviewer javafx:run
```

Or in any JavaFX consumer of `com.lottie4j:fxplayer:1.2.1-SNAPSHOT`:

```java
Animation anim = LottieFileLoader.load(new File("exhale.json"));
LottiePlayer player = new LottiePlayer(anim, 256, 256);
player.play();
// You should see a yellow face exhaling smoke.
// Before this fix, the face was solid orange.
```

The `core/src/test/resources/dot/demo-3-animation.json` rendering also visibly improves (the eyelid mattes were broken with the old direction).
