### PR TITLE
Apply layer-level vector masks (masksProperties) to top-level layers

### DIFF
--- a/fxplayer/src/main/java/com/lottie4j/fxplayer/LottiePlayer.java
+++ b/fxplayer/src/main/java/com/lottie4j/fxplayer/LottiePlayer.java
@@ -60,6 +60,9 @@ public class LottiePlayer extends Canvas {
     private final SolidColorRenderer solidColorRenderer = new SolidColorRenderer();
     private final EffectsRenderer effectsRenderer = new EffectsRenderer();
     private final MatteRenderer matteRenderer = new MatteRenderer();
+    private final com.lottie4j.fxplayer.renderer.layer.MaskRenderer maskRenderer =
+            new com.lottie4j.fxplayer.renderer.layer.MaskRenderer(
+                    new com.lottie4j.fxplayer.renderer.shape.PathBezierInterpolator());
     private final int baseRenderWidth;
     private final int baseRenderHeight;
     private AnimationTimer animationTimer;
@@ -1024,6 +1027,11 @@ public class LottiePlayer extends Canvas {
         // Apply this layer's transform (with opacity)
         applyLayerTransform(gc, layer, frame);
 
+        // Apply layer-level vector masks (masksProperties) so subsequent draws are clipped
+        // to the mask region. The mask coordinates are in the layer's local space, so this
+        // must happen AFTER the layer transform is applied.
+        boolean maskApplied = maskRenderer.applyMasks(gc, layer, frame);
+
         // Handle precomposition layers
         if (layer.layerType() == LayerType.PRECOMPOSITION) {
             renderPrecompositionLayer(gc, layer, frame);
@@ -1076,6 +1084,10 @@ public class LottiePlayer extends Canvas {
             }
         } else {
             logger.debug("Skipping shape rendering for NULL layer: {}", layer.name());
+        }
+
+        if (maskApplied) {
+            maskRenderer.restoreMasks(gc);
         }
 
         gc.restore();
@@ -1375,6 +1387,10 @@ public class LottiePlayer extends Canvas {
      * @param frame current frame
      */
     private void renderLayerContent(GraphicsContext gc, Layer layer, double frame) {
+        // Apply layer-level vector masks (masksProperties). The caller has already applied
+        // any layer transforms, so the mask coordinates resolve in the same local space.
+        boolean maskApplied = maskRenderer.applyMasks(gc, layer, frame);
+
         // Handle precomposition layers
         if (layer.layerType() == LayerType.PRECOMPOSITION) {
             renderPrecompositionLayer(gc, layer, frame);
@@ -1427,6 +1443,10 @@ public class LottiePlayer extends Canvas {
             }
         } else {
             logger.debug("Skipping shape rendering for NULL layer: {}", layer.name());
+        }
+
+        if (maskApplied) {
+            maskRenderer.restoreMasks(gc);
         }
     }
 
@@ -1532,6 +1552,9 @@ public class LottiePlayer extends Canvas {
         // Apply this layer's transform (with opacity)
         applyLayerTransform(gc, layer, frame);
 
+        // Apply layer-level vector masks (masksProperties), in the layer's local space.
+        boolean maskApplied = maskRenderer.applyMasks(gc, layer, frame);
+
         // Handle precomposition layers
         if (layer.layerType() == LayerType.PRECOMPOSITION) {
             renderPrecompositionLayer(gc, layer, frame);
@@ -1574,6 +1597,10 @@ public class LottiePlayer extends Canvas {
             }
         } else {
             logger.debug("Rendering NULL layer: {}", layer.name());
+        }
+
+        if (maskApplied) {
+            maskRenderer.restoreMasks(gc);
         }
 
         gc.restore();


### PR DESCRIPTION
# PR 2 — Apply layer-level vector masks (`masksProperties`) to top-level layers

**Branch**: `pr/apply-layer-masks-top-level` (1 commit, 1 file, +27 / -0)

**File**: `fxplayer/src/main/java/com/lottie4j/fxplayer/LottiePlayer.java`

**Note**: independent of PR 1 (different code paths). Either can land first.

## Title
Apply layer-level vector masks (`masksProperties`) to top-level layers

## Description

Lottie layers may carry their own vector masks under the `masksProperties` JSON field. When a mask is set with mode `"a"` (add), the layer's drawing must be clipped to the mask path so content outside it is not painted.

The `MaskRenderer` collaborator already implements this behavior and is wired into `PrecompRenderer.renderPrecompositionLayerInternal` (around line 432). However, no caller in `LottiePlayer` applied masks to the **top-level** layers. As a result, asset shapes (image / solid / text / shape) drew unclipped, and any masks-only layer (e.g. a typical "flash" effect implemented as a colored solid clipped to a face shape) bled across the entire composition.

### Fix

- Add a `MaskRenderer` field to `LottiePlayer`, parallel to the existing `MatteRenderer`.
- Wrap the layer-type switch in all three top-level rendering paths with `applyMasks` / `restoreMasks`:
  - `renderLayerInternal` (the standard path).
  - `renderLayerInternalWithoutBlendMode` (the path used when a non-`NORMAL` blend mode is present).
  - `renderLayerContent` (the path used inside the off-screen buffer for animated-opacity composition).
- The mask is applied AFTER `applyParentTransforms` / `applyLayerTransform` — or, for `renderLayerContent`, the caller has already applied them — so the mask path coordinates resolve in the layer's local space. This matches the convention used by `PrecompRenderer`.

### Reproduction

Open the attached `face-exhaling-1f62e_200d_1f4a8.zip`. The animation contains a `White Solid 1` layer at index 6:

```json
{
  "ind": 8, "ty": 1, "nm": "White Solid 1",
  "sw": 1024, "sh": 1024, "sc": "#ffffff",
  "ip": 58, "op": 61,
  "ks": { "o": { "a": 0, "k": 100 } },
  "masksProperties": [ {
    "inv": false, "mode": "a",
    "pt": { /* bezier path tracing the face silhouette */ },
    "o": { "a": 0, "k": 100 }
  } ]
}
```

The `masksProperties` array contains one `mode: "a"` mask whose path traces the face silhouette. The intent is a 3-frame white flash CONFINED to the face — a stylistic emphasis as the smoke is exhaled.

**Before the fix**: the `MaskRenderer` was never invoked for this layer, so the white solid rendered as a full-frame 1024×1024 white rectangle. On a small reaction pill (24×24) this is a jarring full-square white flash for 50 ms.

**After the fix**: `MaskRenderer.applyMasks` clips the GraphicsContext to the mask path before `SolidColorRenderer.render` draws, so the white only fills the masked face region.

### Why three call sites

The three rendering paths in `LottiePlayer` all execute the same layer-type switch but under different compositing rules (direct, off-screen for animated opacity, off-screen for blend modes). Applying the mask in only one of them would leave assets that take the other paths un-clipped.

Future cleanup: those three switches duplicate considerable logic; consolidating them into a single helper would let the mask handling live in exactly one place. Out of scope for this PR.

## How to test

Same procedure as PR 1. After this fix, the 😮‍💨 emoji's frame-58–60 white flash appears as a quick white highlight inside the face silhouette instead of a full-frame white square.
